### PR TITLE
Add Trivy IaC scanning workflow

### DIFF
--- a/.github/workflows/trivy-iac.yml
+++ b/.github/workflows/trivy-iac.yml
@@ -1,0 +1,35 @@
+name: Trivy IaC Scan
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Trivy IaC Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in IaC mode
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          hide-progress: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Trivy in IaC scanning mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f233fab2c83339b6f9e50653acca6

## Summary by Sourcery

Add GitHub Actions workflow to run Trivy in IaC scanning mode on push and pull-request events for the main branch, outputting SARIF results and uploading them to the GitHub Security tab.

CI:
- Add Trivy IaC scanning workflow using aquasecurity/trivy-action@0.28.0 with SARIF output and severity filter
- Upload Trivy SARIF results to the GitHub Security tab via github/codeql-action/upload-sarif@v3